### PR TITLE
Revert/2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ jobs:
       node_js:
         - 10
         - 12
-      deploy:
-        on:
-          branch: master
-        provider: script
-        skip_cleanup: true
-        script:
-          - npx semantic-release
+      # deploy:
+      #   on:
+      #     branch: master
+      #   provider: script
+      #   skip_cleanup: true
+      #   script:
+      #     - npx semantic-release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,0 @@
-# [2.6.0](https://github.com/americanexpress/iguazu/compare/v2.5.2...v2.6.0) (2019-12-23)
-
-
-### Features
-
-* **sequence:** Continue sequences with noncritical errors. ([e75dd1f](https://github.com/americanexpress/iguazu/commit/e75dd1fe032ad842312381d26da132ec28e7d37d))
-* **ssr:** replaced ssr methods with isServer ([a8474aa](https://github.com/americanexpress/iguazu/commit/a8474aaa224a317cd008f940759cd8f7020cc86b))
-* **v3:** using new react context, latest redux, and removed lodash ([da6bc8e](https://github.com/americanexpress/iguazu/commit/da6bc8e50a59229d257d659ab3d22cb001e395a6)), closes [#3](https://github.com/americanexpress/iguazu/issues/3)


### PR DESCRIPTION
- Disable deploy for the time being until we fully configure semantic release to release on the 2.x and master (3.x) branches.