### PR TITLE
fix(release): needs to update package json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
-      "@semantic-release/git",
-      "@semantic-release/npm"
+      "@semantic-release/npm",
+      "@semantic-release/git"
     ],
     "branch": "2.x"
   },


### PR DESCRIPTION
**Problem**: When semantic release versions a library on merge to master, it does not increment the version in `package.json` when it tags and publishes it.

**Solution**: Reorder the Semantic Plugins in `package.json` in this manner: https://github.com/semantic-release/git#examples